### PR TITLE
Fuzzy match predicate

### DIFF
--- a/demo/regex_path.js
+++ b/demo/regex_path.js
@@ -1,0 +1,49 @@
+'use strict';
+console.log('REGEX');
+
+// import the mountebank helper library
+const mb_helper = require('../src/index');
+
+// create the skeleton for the imposter (does not post to MB)
+const firstImposter = new mb_helper.Imposter({ 'imposterPort' : 3000 });
+
+// construct sample responses and conditions on which to send it
+const sampleResponse = {
+  'uri' : '/hello',
+  'verb' : 'GET',
+  'res' : {
+    'statusCode': 200,
+    'responseHeaders' : { 'Content-Type' : 'application/json' },
+    'responseBody' : JSON.stringify({ 'hello' : 'world' })
+  }
+};
+
+const working_word_regex = '/pets/\\w+/\\w+';
+const working_number_regex = '/pets/\\d';
+const anotherResponse = {
+  'uri' : working_word_regex,
+  'verb' : 'GET',
+  'res' : {
+    'statusCode': 200,
+    'responseHeaders' : { 'Content-Type' : 'application/json' },
+    'responseBody' : JSON.stringify({ 'somePetAttribute' : 'somePetValue' })
+  }
+};
+
+
+// add our responses to our imposter
+firstImposter.addRoute(anotherResponse);
+const originalStateResponse = firstImposter.getStateReponse();
+
+mb_helper.startMbServer(2525)
+.then( () => {
+  firstImposter.postToMountebank()
+  .then(response => {
+    console.log('response.status: ');
+    console.log(response.status);
+  })
+  .catch(error => {
+    console.log('error: ');
+    console.log(error);
+  });
+});

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "demo-update": "node demo/updateMultipleResponses.js",
     "demo-format": "node demo/stateFormat.js",
     "demo-simple": "node demo/simple.js",
+    "demo-regex": "node demo/regex_path.js",
     "test": "mocha test/*.test.js"
   },
   "engines": {

--- a/src/imposter.js
+++ b/src/imposter.js
@@ -120,7 +120,7 @@ class Imposter {
         // create the MB friendly predicate and response portions
         const mbResponse = Imposter._createResponse(statusCode, responseHeaders, responseBody);
 
-        const mbPredicate = Imposter._createPredicate('equals', { 'method' : verb, 'path' : route } );
+        const mbPredicate = Imposter._createPredicate('matches', { 'method' : verb, 'path' : route } );
 
         // shove these portions into our final complete response in the form of a stub
         CompleteResponse.stubs.push({

--- a/test/mountebank_posting.test.js
+++ b/test/mountebank_posting.test.js
@@ -114,4 +114,41 @@ describe('Posting to MounteBank', function () {
       });
     });
   });
+  describe('RegEx matching', function () {
+    before( function () {
+      const workingWordRegex = '/pets/\\w+/\\w+';
+      const anotherResponse = {
+        'uri' : workingWordRegex,
+        'verb' : 'GET',
+        'res' : {
+          'statusCode': 200,
+          'responseHeaders' : { 'Content-Type' : 'application/json' },
+          'responseBody' : JSON.stringify({ 'somePetAttribute' : 'somePetValue' })
+        }
+      };
+      const testImposter = new Imposter({ 'imposterPort' : 3010 });
+      testImposter.addRoute(anotherResponse);
+      return testImposter.postToMountebank();
+    });
+    it('Hitting an imposter route setup with regex with a matching path should return the response', function () {
+      return fetch('http://localhost:3010/pets/hello/hi')
+      .then( response => {
+        return response.text();
+      })
+      .then( body => {
+        return body.should.equal(JSON.stringify({ 'somePetAttribute' : 'somePetValue' }));
+      });
+    });
+
+    it('Hitting an imposter route setup with regex with a non-matching path should return nothing', function () {
+      console.log('hello from successful postToMountebank');
+      return fetch('http://localhost:3010/pets/hello')
+      .then( response => {
+        return response.text();
+      })
+      .then( body => {
+        return body.should.equal('');
+      });
+    });
+  });
 });

--- a/test/mountebank_posting.test.js
+++ b/test/mountebank_posting.test.js
@@ -11,6 +11,7 @@ chai.use(chaiSubset);
 const mbHelper = require('../src/index');
 const Imposter = mbHelper.Imposter;
 const startMbServer = mbHelper.startMbServer;
+const fetch = require('node-fetch');
 
 describe('Posting to MounteBank', function () {
   before(function startUpMounteBank() {
@@ -76,5 +77,41 @@ describe('Posting to MounteBank', function () {
       return JSON.parse(JSON.parse(body).stubs[0].responses[0].is.body);
     })
     .should.eventually.have.key('updatedAttribute');
+  });
+
+  describe('Complete Imposter Test', function () {
+    it('The correct response is returned when hitting a route on which an imposter is listening on', function () {
+      console.log('hello');
+      const sampleRespnse = {
+        'uri' : '/pets/123',
+        'verb' : 'GET',
+        'res' : {
+          'statusCode': 200,
+          'responseHeaders' : { 'Content-Type' : 'application/json' },
+          'responseBody' : JSON.stringify({ 'somePetAttribute' : 'somePetValue' })
+        }
+      };
+      const testImposter = new Imposter({ 'imposterPort' : 3009 });
+      testImposter.addRoute(sampleRespnse);
+      return testImposter.postToMountebank()
+      .then(function () {
+        console.log('hello from successful postToMountebank');
+        return fetch('http://localhost:3009/pets/123')
+        .then( response => {
+          return response.text();
+        })
+        .then( body => {
+          return body.should.equal(JSON.stringify({ 'somePetAttribute' : 'somePetValue' }));
+        })
+        .catch( error => {
+          console.log('error: ');
+          console.log(error);
+        });
+      })
+      .catch( error => {
+        console.log('error: ');
+        console.log(error);
+      });
+    });
   });
 });


### PR DESCRIPTION
NOT A BREAKING CHANGE :) simply replaced predicate operator with 'match' instead of 'equals' to support mountebanks regex matching. Existing functionality works as is. Added some test cases to ensure correct behavior with regex paths