### PR TITLE
Make Mountebank Helper easy to use in Docker

### DIFF
--- a/src/imposter.js
+++ b/src/imposter.js
@@ -32,13 +32,17 @@ class Imposter {
     if (options.protocol == null) {
       options.protocol = 'http';
     }
+    if (options.mountebankHost == null) {
+      options.mountebankHost = process.env.MOUNTEBANK_HOST || '127.0.0.1'
+    }
     if (options.mountebankPort == null) {
-      options.mountebankPort = 2525;
+      options.mountebankPort = process.env.MOUNTEBANK_PORT || 2525;
     }
     /* This is the JSON representation of our available routes. This will be formatted similarly to swagger. This is NOT the body of our Imposter POST request */
     this.ImposterInformation = {
       'imposterPort': options.imposterPort,
       'mountebankPort': options.mountebankPort,
+      'mountebankHost': options.mountebankHost,
       'protocol': options.protocol,
       'routeInformation': {}
     };
@@ -284,7 +288,7 @@ class Imposter {
    */
   _deleteOldImposter() {
     // make DELETE request to the mountebank server (through fetch)...
-    return fetch(`http://127.0.0.1:${this.ImposterInformation.mountebankPort}/imposters/${this.ImposterInformation.imposterPort}`, {
+    return fetch(`http://${this.ImposterInformation.mountebankHost}:${this.ImposterInformation.mountebankPort}/imposters/${this.ImposterInformation.imposterPort}`, {
         method: 'delete'
       })
       .then(function (response) { // retrieve the text body from the response
@@ -417,9 +421,10 @@ class Imposter {
     const updatedMounteBankRequest = this._createMBPostRequestBody();
 
     // only on a resolved promise from _deleteOldImposter do we post our new-updated Imposter. This is to prevent posting a new imposter before the one is deleted
+    const mbHost = this.ImposterInformation.mountebankHost;
     const mbPort = this.ImposterInformation.mountebankPort;
     return this._deleteOldImposter().then(function () {
-      return fetch(`http://127.0.0.1:${mbPort}/imposters`, {
+      return fetch(`http://${mbHost}:${mbPort}/imposters`, {
           method: 'post',
           headers: {
             'content-type': 'application/json'
@@ -444,7 +449,7 @@ class Imposter {
    */
   postToMountebank() {
     const MBBody = this._createMBPostRequestBody();
-    const fetchReturnValue = fetch(`http://127.0.0.1:${this.ImposterInformation.mountebankPort}/imposters`, {
+    const fetchReturnValue = fetch(`http://${this.ImposterInformation.mountebankHost}:${this.ImposterInformation.mountebankPort}/imposters`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json'

--- a/src/imposter.js
+++ b/src/imposter.js
@@ -16,6 +16,7 @@ class Imposter {
   /**
    * Sets up the skeleton for the routeInformation POST request body that will be sent to the Mountebank server to set up the imposter
    * @param  {Object} options     The set of options to configure the imposter
+   * @param  {String} options.mountebankHost     The name of the network host or ip address of the Mountebank server (defaults to 127.0.0.1)
    * @param  {Number} options.mountebankPort     The port number on which the Mountebank server is to listen on (defaults to 2525)
    * @param  {Number} options.imposterPort     The port number on which this particular Imposter is to listen on
    * @param  {String} options.protocol     The protocol that the imposter is to listen on. Options are http, https, tcp, and smtp (defaults to http)

--- a/src/imposter.js
+++ b/src/imposter.js
@@ -187,14 +187,14 @@ class Imposter {
 
   /**
    * This will take in the desired response components (status, headers, and body) and construct a mountebank-style response. Takes care of rigid formatting that MB requires
-   * @param  {Number} statuscode The status code that the user wishes to have returned from the imposter
+   * @param  {Number} statusCode The status code that the user wishes to have returned from the imposter
    * @param  {Object} headers    The headers to be returned as part of the imposters response
    * @param  {String} body       The body to be returned as part of the imposters response
    * @return {Object}            The mountebank-formatted response object that can be added as part of a mountebank stub
    */
-  static _createResponse(statuscode, headers, body) {
-    if (!_.isNumber(statuscode)) {
-      throw new TypeError('statuscode must be a number');
+  static _createResponse(statusCode, headers, body) {
+    if (!_.isNumber(statusCode)) {
+      throw new TypeError('statusCode must be a number');
     }
     if (!_.isObject(headers)) {
       throw new TypeError('headers must be an object');
@@ -205,7 +205,7 @@ class Imposter {
     const finalResponse = {};
     const response = {};
 
-    response.statuscode = statuscode;
+    response.statusCode = statusCode;
     response.headers = headers;
     response.body = body;
     /* A mountebank formatting thing where each response has a type (is, proxy, or inject) and this type must be specified in the form of a key where the value the actual response */

--- a/src/index.js
+++ b/src/index.js
@@ -6,7 +6,7 @@ const tcpPortUsed = require('tcp-port-used');
 exports.Imposter = require('./imposter');
 
 exports.startMbServer = function (port) {
-  return tcpPortUsed.check(port, '127.0.0.1')
+  return tcpPortUsed.check(port, process.env.MOUNTEBANK_HOST || '127.0.0.1')
   .then( function(inUse) {
     if (inUse == true) {
       return Promise.resolve(`Port ${port} is already in use!`);

--- a/src/index.js
+++ b/src/index.js
@@ -6,7 +6,7 @@ const tcpPortUsed = require('tcp-port-used');
 exports.Imposter = require('./imposter');
 
 exports.startMbServer = function (port) {
-  return tcpPortUsed.check(port, process.env.MOUNTEBANK_HOST || '127.0.0.1')
+  return tcpPortUsed.check(port, '127.0.0.1')
   .then( function(inUse) {
     if (inUse == true) {
       return Promise.resolve(`Port ${port} is already in use!`);

--- a/test/custom_predicates_responses.test.js
+++ b/test/custom_predicates_responses.test.js
@@ -108,7 +108,7 @@ describe('Route Information with custom predicates and MB Post Request Body', fu
         predicates,
         responses: [{
           is: {
-            statuscode: 200,
+            statusCode: 200,
             headers: {
               'Content-Type': 'application/json'
             },
@@ -120,7 +120,7 @@ describe('Route Information with custom predicates and MB Post Request Body', fu
         predicates,
         responses: [{
           is: {
-            statuscode: 200,
+            statusCode: 200,
             headers: {
               'Content-Type': 'application/json'
             },
@@ -132,7 +132,7 @@ describe('Route Information with custom predicates and MB Post Request Body', fu
         predicates,
         responses: [{
           is: {
-            statuscode: 200,
+            statusCode: 200,
             headers: {
               'Content-Type': 'application/json'
             },
@@ -144,7 +144,7 @@ describe('Route Information with custom predicates and MB Post Request Body', fu
         predicates,
         responses: [{
           is: {
-            statuscode: 200,
+            statusCode: 200,
             headers: {
               'Content-Type': 'application/json'
             },

--- a/test/input_validation.test.js
+++ b/test/input_validation.test.js
@@ -56,6 +56,32 @@ describe('Input Validation', function () {
         });
       }).to.not.throw();
     });
+
+    describe ('Host url', function() {
+      afterEach(function () {
+        delete process.env.MOUNTEBANK_HOST;
+      });
+      
+      it('Should use the mountebank server host supplied in the options', function () {
+        expect(new Imposter({
+          'mountebankHost': 'opt-host.com',
+          'imposterPort': 3000
+        }).ImposterInformation.mountebankHost).to.equal('opt-host.com');
+      });
+
+      it('Should use the mountebank server host supplied in the environment', function () {
+        process.env.MOUNTEBANK_HOST = 'env-host.info'
+        expect(new Imposter({
+          'imposterPort': 3000
+        }).ImposterInformation.mountebankHost).to.equal('env-host.info');
+      });
+
+      it('Should default the mountebank server host 127.0.0.1 when host is not supplied', function () {
+        expect(new Imposter({
+          'imposterPort': 3000
+        }).ImposterInformation.mountebankHost).to.equal('127.0.0.1');
+      });
+    });
   });
 
   describe('Response Construction', function () {

--- a/test/input_validation.test.js
+++ b/test/input_validation.test.js
@@ -59,14 +59,14 @@ describe('Input Validation', function () {
   });
 
   describe('Response Construction', function () {
-    it('Should throw if statuscode is not a number', function () {
+    it('Should throw if statusCode is not a number', function () {
       expect(function () {
         Imposter._createResponse('hello', {
           'Content-Type': 'application/json'
         }, JSON.stringify({
           'hello': 'world'
         }));
-      }).to.throw('statuscode must be a number');
+      }).to.throw('statusCode must be a number');
     });
     it('Should throw if headers is not an object', function () {
       expect(function () {

--- a/test/input_validation.test.js
+++ b/test/input_validation.test.js
@@ -41,13 +41,6 @@ describe('Input Validation', function () {
       }).ImposterInformation.protocol).to.equal('http');
     });
 
-    it('Should default to setting mountebankPort to 2525 if one is not supplied', function () {
-      expect(new Imposter({
-        'protocol': 'http',
-        'imposterPort': 3000
-      }).ImposterInformation.mountebankPort).to.equal(2525);
-    });
-
     it('Should NOT throw if proper arguments are specified', function () {
       expect(function () {
         new Imposter({
@@ -57,30 +50,53 @@ describe('Input Validation', function () {
       }).to.not.throw();
     });
 
-    describe ('Host url', function() {
+    describe ('Mountebank server url', function() {
       afterEach(function () {
         delete process.env.MOUNTEBANK_HOST;
+        delete process.env.MOUNTEBANK_PORT;
       });
       
-      it('Should use the mountebank server host supplied in the options', function () {
+      it('Should set the mountebankHost to the value supplied in the options.mountebankHost', function () {
         expect(new Imposter({
           'mountebankHost': 'opt-host.com',
           'imposterPort': 3000
         }).ImposterInformation.mountebankHost).to.equal('opt-host.com');
       });
 
-      it('Should use the mountebank server host supplied in the environment', function () {
+      it('Should set the mountebankHost to the value supplied in the MOUNTEBANK_HOST environment variable', function () {
         process.env.MOUNTEBANK_HOST = 'env-host.info'
         expect(new Imposter({
           'imposterPort': 3000
         }).ImposterInformation.mountebankHost).to.equal('env-host.info');
       });
 
-      it('Should default the mountebank server host 127.0.0.1 when host is not supplied', function () {
+      it('Should default mountebankHost to 127.0.0.1 when options.mountebankHost is not supplied', function () {
         expect(new Imposter({
           'imposterPort': 3000
         }).ImposterInformation.mountebankHost).to.equal('127.0.0.1');
       });
+      
+      it('Should set mountebankPort to the one supplied in optiont.mountebankPort', function () {
+        expect(new Imposter({
+          'mountebankPort': 666,
+          'imposterPort': 3000
+        }).ImposterInformation.mountebankPort).to.equal(666);
+      });
+      
+      it('Should set mountebankPort to the one supplied in MOUNTEBANK_PORT environment variable', function () {
+        process.env.MOUNTEBANK_PORT = 6666;
+        expect(new Imposter({
+          'imposterPort': 3000
+        }).ImposterInformation.mountebankPort).to.equal('6666');
+      });
+      
+      it('Should default to setting mountebankPort to 2525 if one is not supplied', function () {
+        expect(new Imposter({
+          'protocol': 'http',
+          'imposterPort': 3000
+        }).ImposterInformation.mountebankPort).to.equal(2525);
+      });
+
     });
   });
 

--- a/test/mountebank_posting.test.js
+++ b/test/mountebank_posting.test.js
@@ -145,7 +145,7 @@ describe('Posting to MounteBank', function () {
       return testImposter.updateResponseCode(201, { 'uri' : '/pets/123', 'verb' : 'PUT' });
     })
     .then(function (body) {
-      return JSON.parse(body).stubs[0].responses[0].is.statuscode;
+      return JSON.parse(body).stubs[0].responses[0].is.statusCode;
     })
     .should.eventually.equal(201);
   });

--- a/test/predicates_responses_states.test.js
+++ b/test/predicates_responses_states.test.js
@@ -123,7 +123,7 @@ describe('Route Information and MB Post Request Body', function () {
         }],
         responses: [{
           is: {
-            statuscode: 200,
+            statusCode: 200,
             headers: {
               'Content-Type': 'application/json'
             },
@@ -140,7 +140,7 @@ describe('Route Information and MB Post Request Body', function () {
         }],
         responses: [{
           is: {
-            statuscode: 200,
+            statusCode: 200,
             headers: {
               'Content-Type': 'application/json'
             },
@@ -157,7 +157,7 @@ describe('Route Information and MB Post Request Body', function () {
         }],
         responses: [{
           is: {
-            statuscode: 200,
+            statusCode: 200,
             headers: {
               'Content-Type': 'application/json'
             },
@@ -174,7 +174,7 @@ describe('Route Information and MB Post Request Body', function () {
         }],
         responses: [{
           is: {
-            statuscode: 200,
+            statusCode: 200,
             headers: {
               'Content-Type': 'application/json'
             },

--- a/test/testStubs.js
+++ b/test/testStubs.js
@@ -6,7 +6,7 @@ module.exports.samplePredicate = {
 
 module.exports.sampleReponse = {
   is: {
-    statuscode: 200,
+    statusCode: 200,
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ 'hello' : 'world' })
   }


### PR DESCRIPTION
Hi @Tzinov15,

Love your work, just wanted to to make it a bit easier to use the helper in docker where the mountebank host might be in a separate container to the tests. Fixing mb host to localhost requires docker/linux acrobatics to forward the port to another container. It is a bit cleaner if it were possible to specify the host in mountebank helper instead.

Cheers